### PR TITLE
add metrics

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/onflow/flow-archive-access/metrics"
 	"github.com/onflow/flow-go/fvm/blueprints"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -41,6 +43,7 @@ type Server struct {
 	index   archive.Reader
 	codec   archive.Codec
 	invoker Invoker
+	metrics *metrics.APIMetricsCollector
 }
 
 // NewServer creates a new server, using the provided index reader as a backend

--- a/cmd/archive-access-api/main.go
+++ b/cmd/archive-access-api/main.go
@@ -16,13 +16,15 @@ package main
 
 import (
 	"errors"
-	"google.golang.org/grpc/credentials/insecure"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/pflag"
@@ -98,6 +100,10 @@ func run() int {
 			logging.StreamServerInterceptor(grpczerolog.InterceptorLogger(log), opts...),
 		),
 	)
+
+	// automatically add metrics with grpc_server_handled_total{grpc_code="Internal|Unknown|OK"}
+	grpc_prometheus.EnableHandlingTimeHistogram()
+	grpc_prometheus.Register(gsvr)
 
 	// Initialize the API client.
 	conn, err := grpc.Dial(flagArchive, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/googleapis/go-type-adapters v1.0.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,7 @@ github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.2/go
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-20200501113911-9a95f0fdbfea/go.mod h1:GugMBs30ZSAkckqXEAIEGyYdDH6EgqowG8ppA3Zt+AY=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2 h1:1aeRCnE2CkKYqyzBu0+B2lgTcZPc3ea2lGpijeHbI1c=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2/go.mod h1:GhphxcdlaRyAuBSvo6rV71BvQcvB/vuX8ugCyybuS2k=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=


### PR DESCRIPTION
Add Metrics to all GRPC calls. It will automatically add metrics, such that we can monitor with the following queries:
```
sum by (grpc_method) (rate(grpc_server_handled_total{network="$network",role="archive-access",num=~"005|006",grpc_code="OK"}[2m]))
```